### PR TITLE
Fix infinite loop when client closes TCP connection with a FIN flag

### DIFF
--- a/src/main/kotlin/xyz/poeschl/slowwave/SlowwaveApplication.kt
+++ b/src/main/kotlin/xyz/poeschl/slowwave/SlowwaveApplication.kt
@@ -70,6 +70,7 @@ class SlowwaveApplication(host: String, listeningPort: Int,
               while (true) {
                 val input = receiveChannel.readUTF8Line()
                 if (input == null) {
+                  // Client has closed the connection.
                   break;
                 }
 

--- a/src/main/kotlin/xyz/poeschl/slowwave/SlowwaveApplication.kt
+++ b/src/main/kotlin/xyz/poeschl/slowwave/SlowwaveApplication.kt
@@ -67,23 +67,25 @@ class SlowwaveApplication(host: String, listeningPort: Int,
             statistics.syncConnectionCount(openConnections)
 
             try {
-              while (socket.isActive) {
+              while (true) {
                 val input = receiveChannel.readUTF8Line()
-                if (input != null) {
-                  val request = Request(remoteAddress, input.split(" "))
+                if (input == null) {
+                  break;
+                }
 
-                  val response =
-                      when (request.cmd[0]) {
-                        pxCommand.command -> pxCommand.handleCommand(request)
-                            tokenCommand.command -> tokenCommand.handleCommand(request)
-                            sizeCommand.command -> sizeCommand.handleCommand(request)
-                            offsetCommand.command -> offsetCommand.handleCommand(request)
-                            helpCommand.command -> helpCommand.handleCommand(request)
-                            else -> ""
-                          }
-                  if (response.isNotBlank()) {
-                    sendChannel.writeStringUtf8(response + "\n")
-                  }
+                val request = Request(remoteAddress, input.split(" "))
+
+                val response =
+                    when (request.cmd[0]) {
+                      pxCommand.command -> pxCommand.handleCommand(request)
+                          tokenCommand.command -> tokenCommand.handleCommand(request)
+                          sizeCommand.command -> sizeCommand.handleCommand(request)
+                          offsetCommand.command -> offsetCommand.handleCommand(request)
+                          helpCommand.command -> helpCommand.handleCommand(request)
+                          else -> ""
+                        }
+                if (response.isNotBlank()) {
+                  sendChannel.writeStringUtf8(response + "\n")
                 }
               }
             } catch (e: Exception) {


### PR DESCRIPTION
Fix an infinite loop when a client closes the TCP connection with a FIN flag (normal close).

This should be indicated by `receiveChannel.readUTF8Line()` returning `null`, but previously in that case the loop continued as `socket.isActive` was still `true`, probably because the socket was only half-closed, thus causing an infinite loop in that case.
<br>

For example, when running `sudo docker run --network host ghcr.io/poeschl/slowwave --width 1280 --height 720` on Ubuntu 22.04, and then opening and closing a TCP connection to Slowwave (port 1234) two times, `top` will show `java` consuming 2 CPU cores:
![grafik](https://github.com/Poeschl/slowwave/assets/13289184/8e131b9d-108a-4f0c-80c4-b41febccf42b)

Opening and closing another TCP connection will show `java` consuming 3 CPU cores:

![grafik](https://github.com/Poeschl/slowwave/assets/13289184/ccfb41fe-8dd4-4a21-9b11-9fe5dc038415)

`sudo netstat -tupen | grep ":1234"` will show that the three connections are in `CLOSE_WAIT` state, meaning that the remote endpoint has closed the connection, but the local endpoint didn't yet close it:

![grafik](https://github.com/Poeschl/slowwave/assets/13289184/5152038b-8ffd-4b9e-88f4-766324ca764d)

I have tested that with the changes from this PR, the issue doesn't occur any more.

(However, please note that I know almost nothing about Kotlin, and haven't used Java in a long time.)

Thanks!